### PR TITLE
Remove explicit gcc version from cargo config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN rustup default nightly
 RUN rustup target add arm-unknown-linux-gnueabihf
 RUN mkdir source \
 &&  mkdir .cargo \
-&&  echo "[target.arm-unknown-linux-gnueabihf]\nlinker = \"arm-linux-gnueabihf-gcc-4.8\"" > .cargo/config
+&&  echo "[target.arm-unknown-linux-gnueabihf]\nlinker = \"arm-linux-gnueabihf-gcc\"" > .cargo/config
 WORKDIR source
 CMD ["bash"]


### PR DESCRIPTION
The gcc version in gcc-arm-linux-gnueabihf is now up to 5.4, so there is no binary named arm-linux-gnueabihf-gcc-4.8. Seems simpler and more maintainable just to use whatever version we can get.